### PR TITLE
Allow users inside container access to sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,25 @@ RUN pip install behave==1.2.6 pyhamcrest==1.10.1
 # Install python3 dependencies
 RUN pip3 install transient==0.10
 
+# Allow any user to have sudo access within the container
+ARG VER=1
+ARG ZIP_FILE=add-user-to-sudoers.zip
+RUN wget -nv "https://github.com/starlab-io/add-user-to-sudoers/releases/download/${VER}/${ZIP_FILE}" && \
+    unzip "${ZIP_FILE}" && \
+    rm "${ZIP_FILE}" && \
+    mkdir -p /usr/local/bin && \
+    mv add_user_to_sudoers /usr/local/bin/ && \
+    mv startup_script /usr/local/bin/ && \
+    chmod 4755 /usr/local/bin/add_user_to_sudoers && \
+    chmod +x /usr/local/bin/startup_script && \
+    # Let regular users be able to use sudo
+    echo $'auth       sufficient    pam_permit.so\n\
+account    sufficient    pam_permit.so\n\
+session    sufficient    pam_permit.so\n\
+' > /etc/pam.d/sudo
+
 ENV LC_ALL=en_US.utf-8
 ENV LANG=en_US.utf-8
+
+ENTRYPOINT ["/usr/local/bin/startup_script"]
+CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
The crucible build requires root access inside the container. Typically, this
was enabled by just running the container as the root user, but then this
requires the user to use sudo in order to cleanup any left over artifacts.

This change will allow the container to be kicked off as a non-root user, but
still get root inside the container without `docker exec`ing from another shell.

Then the build scripts can change the owners of build artifacts before the
container is shutdown.