### PR TITLE
Add dependency for new stubdom tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ LABEL maintainer="Adam Schwalm <adam.schwalm@starlab.io>"
 RUN yum install -y \
     # Add the EPEL for python3 and other new packages \
     epel-release \
+    # Add software collections \
+    centos-release-scl \
     # Add the overlay plugin \
     yum-plugin-ovl \
     # Add endpoint for the updated git version (needed for titanium) \
@@ -26,7 +28,7 @@ RUN yum update -y && yum install -y \
     git libfdt-devel zlib-devel \
     \
     # Crucible build dependencies \
-    squashfs-tools \
+    squashfs-tools llvm-toolset-7 \
     \
     # Dependencies for starting build as non-root user \
     sudo \


### PR DESCRIPTION
The libvchan-wrapper program written to pass files between dom0 and device model stubdomains requires libclang to build. The version of clang in the base centos 7 repos is too old, so we add the `llvm-toolset-7` software collection as a dependency.